### PR TITLE
Fix for issue #30

### DIFF
--- a/lib/tasks/load_data.rake
+++ b/lib/tasks/load_data.rake
@@ -176,7 +176,7 @@ namespace :iom do
              file.write(uri.read)
           end
         end
-     end
+      end
 
       sql = File.read("#{Rails.root}/db/data/admin2_regions.sql")
       statements = sql.split(/;$/)


### PR DESCRIPTION
When paging through the tmp_countries table, unstable ordering was causing some rows to be skipped.
