### PR TITLE
don't filter out past projects when querying for map pins

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -68,7 +68,7 @@ class ActivitiesController < ApplicationController
               from regions as r
                 inner join projects_regions as pr on r.id=pr.region_id and r.level=#{@site.level_for_region}
                 inner join projects_sites as ps on pr.project_id=ps.project_id and ps.site_id=#{@site.id}
-                inner join projects as p on ps.project_id=p.id and (p.end_date is null OR p.end_date > now())
+                inner join projects as p on ps.project_id=p.id
                 left outer join projects_activities as pa on pa.project_id=p.id and pa.activity_id=#{params[:id].sanitize_sql!.to_i}
                 #{location_filter}
                 group by r.id,r.name,lon,lat,r.name,r.code,start_year,end_year"
@@ -89,7 +89,7 @@ class ActivitiesController < ApplicationController
                  (select count(*) from data_denormalization where regions_ids && ('{'||r.id||'}')::integer[] and (end_date is null OR end_date > now()) and site_id=#{@site.id}) as total_in_region
                  from projects_regions as pr
                  inner join projects_sites as ps on pr.project_id=ps.project_id and ps.site_id=#{@site.id}
-                 inner join projects as p on pr.project_id=p.id and (p.end_date is NULL OR p.end_date > now())
+                 inner join projects as p on pr.project_id=p.id
                  inner join regions as r on pr.region_id=r.id and r.level=#{@site.levels_for_region.min} and r.country_id=#{@filter_by_location.first}
                  inner join projects_activities as pa on pa.project_id=p.id and pa.activity_id=#{params[:id].sanitize_sql!.to_i}
                  group by r.id,r.name,lon,lat,r.code,start_year,end_year"
@@ -109,7 +109,7 @@ class ActivitiesController < ApplicationController
                  r.code
                  from projects_regions as pr
                  inner join projects_sites as ps on pr.project_id=ps.project_id and ps.site_id=#{@site.id}
-                 inner join projects as p on pr.project_id=p.id and (p.end_date is NULL or p.end_date > now())
+                 inner join projects as p on pr.project_id=p.id
                  inner join regions as r on pr.region_id=r.id and r.level=#{@site.levels_for_region.min} and r.country_id=#{@filter_by_location.shift} and r.id in (#{@filter_by_location.join(',')})
                  inner join projects_activities as pa on pa.project_id=p.id and pa.activity_id=#{params[:id].sanitize_sql!.to_i}
                  group by r.id,r.name,lon,lat,r.path,r.code,start_year,end_year"
@@ -128,7 +128,7 @@ class ActivitiesController < ApplicationController
                 from countries as c
                   inner join countries_projects as cp on c.id=cp.country_id
                   inner join projects_sites as ps on cp.project_id=ps.project_id and ps.site_id=#{@site.id}
-                  inner join projects as p on ps.project_id=p.id and (p.end_date is null OR p.end_date > now())
+                  inner join projects as p on ps.project_id=p.id
                   left outer join projects_activities as pa on pa.project_id=p.id and pa.activity_id=#{params[:id].sanitize_sql!.to_i}
                   #{location_filter}
                   group by c.id,c.name,lon,lat,c.name,start_year,end_year"

--- a/app/controllers/audience_controller.rb
+++ b/app/controllers/audience_controller.rb
@@ -78,7 +78,7 @@ class AudienceController < ApplicationController
               from regions as r
                 inner join projects_regions as pr on r.id=pr.region_id and r.level=#{@site.level_for_region}
                 inner join projects_sites as ps on pr.project_id=ps.project_id and ps.site_id=#{@site.id}
-                inner join projects as p on ps.project_id=p.id and (p.end_date is null OR p.end_date > now())
+                inner join projects as p on ps.project_id=p.id
                 inner join projects_audiences as pa on pa.project_id=p.id and pa.audience_id=#{params[:id].sanitize_sql!.to_i}
                 #{location_filter}
                 group by r.id,r.name,lon,lat,r.code,start_year,end_year"
@@ -99,7 +99,7 @@ class AudienceController < ApplicationController
                  (select count(*) from data_denormalization where regions_ids && ('{'||r.id||'}')::integer[] and (end_date is null OR end_date > now()) and site_id=#{@site.id}) as total_in_region
                  from projects_regions as pr
                  inner join projects_sites as ps on pr.project_id=ps.project_id and ps.site_id=#{@site.id}
-                 inner join projects as p on pr.project_id=p.id and (p.end_date is NULL OR p.end_date > now())
+                 inner join projects as p on pr.project_id=p.id
                  inner join regions as r on pr.region_id=r.id and r.level=#{@site.levels_for_region.min} and r.country_id=#{@filter_by_location.first}
                  inner join projects_audiences as pa on pa.project_id=p.id and pa.audience_id=#{params[:id].sanitize_sql!.to_i}
                  group by r.id,r.name,lon,lat,r.code,start_year,end_year"
@@ -119,7 +119,7 @@ class AudienceController < ApplicationController
                  r.code
                  from projects_regions as pr
                  inner join projects_sites as ps on pr.project_id=ps.project_id and ps.site_id=#{@site.id}
-                 inner join projects as p on pr.project_id=p.id and (p.end_date is NULL or p.end_date > now())
+                 inner join projects as p on pr.project_id=p.id
                  inner join regions as r on pr.region_id=r.id and r.level=#{@site.levels_for_region.min} and r.country_id=#{@filter_by_location.shift} and r.id in (#{@filter_by_location.join(',')})
                  inner join projects_audiences as pa on pa.project_id=p.id and pa.audience_id=#{params[:id].sanitize_sql!.to_i}
                  group by r.id,r.name,lon,lat,r.path,r.code,start_year,end_year"
@@ -137,7 +137,7 @@ class AudienceController < ApplicationController
                 from countries as c
                   inner join countries_projects as cp on c.id=cp.country_id
                   inner join projects_sites as ps on cp.project_id=ps.project_id and ps.site_id=#{@site.id}
-                  inner join projects as p on ps.project_id=p.id and (p.end_date is null OR p.end_date > now())
+                  inner join projects as p on ps.project_id=p.id
                   left outer join projects_audiences as pa on pa.project_id=p.id and pa.audience_id=#{params[:id].sanitize_sql!.to_i}
                   group by c.id,c.name,lon,lat,c.name,start_year,end_year"
         end

--- a/app/controllers/clusters_sectors_controller.rb
+++ b/app/controllers/clusters_sectors_controller.rb
@@ -108,7 +108,7 @@ class ClustersSectorsController < ApplicationController
             from regions as r
               inner join projects_regions as pr on r.id=pr.region_id and r.level=#{@site.level_for_region}
               inner join projects_sites as ps on pr.project_id=ps.project_id and ps.site_id=#{@site.id}
-              inner join projects as p on ps.project_id=p.id and (p.end_date is null OR p.end_date > now())
+              inner join projects as p on ps.project_id=p.id
               left outer join clusters_projects as cp on cp.project_id=p.id and cp.cluster_id=#{params[:id].sanitize_sql!.to_i}
               #{location_filter}
               group by r.id,r.name,lon,lat,r.name,url,r.code"
@@ -119,7 +119,7 @@ class ClustersSectorsController < ApplicationController
               from countries as c
                 inner join countries_projects as cp on c.id=cp.country_id
                 inner join projects_sites as ps on cp.project_id=ps.project_id and ps.site_id=#{@site.id}
-                inner join projects as p on ps.project_id=p.id and (p.end_date is null OR p.end_date > now())
+                inner join projects as p on ps.project_id=p.id
                 left outer join clusters_projects as cpr on cpr.project_id=p.id and cpr.cluster_id=#{params[:id].sanitize_sql!.to_i}
                 #{location_filter}
                 group by c.id,c.name,lon,lat,c.name,url"
@@ -141,7 +141,7 @@ class ClustersSectorsController < ApplicationController
             from regions as r
               inner join projects_regions as pr on r.id=pr.region_id and r.level=#{@site.level_for_region}
               inner join projects_sites as ps on pr.project_id=ps.project_id and ps.site_id=#{@site.id}
-              inner join projects as p on ps.project_id=p.id and (p.end_date is null OR p.end_date > now())
+              inner join projects as p on ps.project_id=p.id
               left outer join projects_sectors as pse on pse.project_id=p.id and pse.sector_id=#{params[:id].sanitize_sql!.to_i}
               #{location_filter}
               group by r.id,r.name,lon,lat,r.path,r.code"
@@ -168,7 +168,7 @@ class ClustersSectorsController < ApplicationController
                    from regions as r
                    inner join projects_regions as pr on r.id=pr.region_id
                    inner join projects_sites as ps on pr.project_id=ps.project_id and ps.site_id=#{@site.id}
-                    inner join projects as p on ps.project_id=p.id and (p.end_date is null OR p.end_date > now())
+                    inner join projects as p on ps.project_id=p.id
                     left outer join projects_sectors as pse on pse.project_id=p.id and pse.sector_id=#{params[:id].sanitize_sql!.to_i}
                     inner join countries c on r.country_id = c.id
                     where #{region_location_filter}
@@ -191,8 +191,6 @@ class ClustersSectorsController < ApplicationController
                   INNER JOIN projects_sites AS ps ON cp.project_id=ps.project_id
                   AND ps.site_id=#{@site.id}
                   INNER JOIN projects AS p ON ps.project_id=p.id
-                  AND (p.end_date IS NULL
-                       OR p.end_date > now())
                   INNER JOIN projects_sectors AS pse ON pse.project_id=p.id
                   AND pse.sector_id=#{params[:id].sanitize_sql!.to_i}
                   AND #{country_location_filter}
@@ -209,7 +207,7 @@ class ClustersSectorsController < ApplicationController
                 from countries as c
                   inner join countries_projects as cp on c.id=cp.country_id
                   inner join projects_sites as ps on cp.project_id=ps.project_id and ps.site_id=#{@site.id}
-                  inner join projects as p on ps.project_id=p.id and (p.end_date is null OR p.end_date > now())
+                  inner join projects as p on ps.project_id=p.id
                   left outer join projects_sectors as pse on pse.project_id=p.id and pse.sector_id=#{params[:id].sanitize_sql!.to_i}
                   group by c.id,c.name,lon,lat,c.name"
             end

--- a/app/controllers/diseases_controller.rb
+++ b/app/controllers/diseases_controller.rb
@@ -72,7 +72,7 @@ class DiseasesController < ApplicationController
               from regions as r
                 inner join projects_regions as pr on r.id=pr.region_id and r.level=#{@site.level_for_region}
                 inner join projects_sites as ps on pr.project_id=ps.project_id and ps.site_id=#{@site.id}
-                inner join projects as p on ps.project_id=p.id and (p.end_date is null OR p.end_date > now())
+                inner join projects as p on ps.project_id=p.id
                 inner join diseases_projects as pa on pa.project_id=p.id and pa.disease_id=#{params[:id].sanitize_sql!.to_i}
                 #{location_filter}
                 group by r.id,r.name,lon,lat,r.name,r.code,start_year,end_year"
@@ -93,7 +93,7 @@ class DiseasesController < ApplicationController
                  (select count(*) from data_denormalization where regions_ids && ('{'||r.id||'}')::integer[] and (end_date is null OR end_date > now()) and site_id=#{@site.id}) as total_in_region
                  from projects_regions as pr
                  inner join projects_sites as ps on pr.project_id=ps.project_id and ps.site_id=#{@site.id}
-                 inner join projects as p on pr.project_id=p.id and (p.end_date is NULL OR p.end_date > now())
+                 inner join projects as p on pr.project_id=p.id
                  inner join regions as r on pr.region_id=r.id and r.level=#{@site.levels_for_region.min} and r.country_id=#{@filter_by_location.first}
                  inner join diseases_projects as pa on pa.project_id=p.id and pa.disease_id=#{params[:id].sanitize_sql!.to_i}
                  group by r.id,r.name,lon,lat,r.code,start_year,end_year"
@@ -113,7 +113,7 @@ class DiseasesController < ApplicationController
                  r.code
                  from projects_regions as pr
                  inner join projects_sites as ps on pr.project_id=ps.project_id and ps.site_id=#{@site.id}
-                 inner join projects as p on pr.project_id=p.id and (p.end_date is NULL or p.end_date > now())
+                 inner join projects as p on pr.project_id=p.id
                  inner join regions as r on pr.region_id=r.id and r.level=#{@site.levels_for_region.min} and r.country_id=#{@filter_by_location.shift} and r.id in (#{@filter_by_location.join(',')})
                  inner join diseases_projects as pa on pa.project_id=p.id and pa.disease_id=#{params[:id].sanitize_sql!.to_i}
                  group by r.id,r.name,lon,lat,r.path,r.code,start_year,end_year"
@@ -132,7 +132,7 @@ class DiseasesController < ApplicationController
                 from countries as c
                   inner join countries_projects as cp on c.id=cp.country_id
                   inner join projects_sites as ps on cp.project_id=ps.project_id and ps.site_id=#{@site.id}
-                  inner join projects as p on ps.project_id=p.id and (p.end_date is null OR p.end_date > now())
+                  inner join projects as p on ps.project_id=p.id
                   inner join diseases_projects as pa on pa.project_id=p.id and pa.disease_id=#{params[:id].sanitize_sql!.to_i}
                   #{location_filter}
                   group by c.id,c.name,lon,lat,c.name,start_year,end_year"

--- a/app/controllers/donors_controller.rb
+++ b/app/controllers/donors_controller.rb
@@ -254,7 +254,7 @@ class DonorsController < ApplicationController
                   r.code
                 FROM projects_regions AS pr
                 INNER JOIN projects_sites AS ps ON pr.project_id=ps.project_id AND ps.site_id=#{@site.id}
-                INNER JOIN projects AS p ON pr.project_id=p.id AND (p.end_date is NULL OR p.end_date > now())
+                INNER JOIN projects AS p ON pr.project_id=p.id
                 INNER JOIN regions AS r ON pr.region_id=r.id AND r.level=#{@site.levels_for_region.min} AND r.country_id=#{@filter_by_location.first}
                 INNER JOIN donations on donations.project_id = p.id
                 #{category_join}
@@ -270,7 +270,7 @@ class DonorsController < ApplicationController
                   null as url,
                   c.code
                 FROM projects AS p
-                INNER JOIN projects_sites AS ps ON ps.site_id=#{@site.id} and ps.project_id = p.id AND (p.end_date is NULL OR p.end_date > now())
+                INNER JOIN projects_sites AS ps ON ps.site_id=#{@site.id} and ps.project_id = p.id
                 INNER JOIN donations on donations.project_id = p.id
                 INNER JOIN countries as c ON c.id = #{params[:location_id]}
                 INNER JOIN countries_projects as cp on cp.country_id = c.id AND cp.project_id = p.id
@@ -295,7 +295,7 @@ class DonorsController < ApplicationController
                          r.code
                   FROM projects_regions AS pr
                   INNER JOIN projects_sites AS ps ON pr.project_id=ps.project_id AND ps.site_id=#{@site.id}
-                  INNER JOIN projects AS p ON pr.project_id=p.id AND (p.end_date is NULL OR p.end_date > now())
+                  INNER JOIN projects AS p ON pr.project_id=p.id
                   INNER JOIN regions AS r ON pr.region_id=r.id AND r.level=#{@site.levels_for_region.min} AND r.country_id=#{@filter_by_location.shift} AND r.id IN (#{@filter_by_location.join(',')})
                   INNER JOIN donations on donations.project_id = p.id
                   #{category_join}

--- a/app/controllers/georegion_controller.rb
+++ b/app/controllers/georegion_controller.rb
@@ -72,7 +72,7 @@ class GeoregionController < ApplicationController
                   END as url,
                   r.code, 'region' as type
                   from ((projects_regions as pr inner join projects_sites as ps on pr.project_id=ps.project_id and ps.site_id=#{@site.id})
-                  inner join projects as p on pr.project_id=p.id and (p.end_date is null OR p.end_date > now())
+                  inner join projects as p on pr.project_id=p.id
                   inner join regions as r on pr.region_id=r.id and r.level=#{@site.levels_for_region.min} and r.country_id=#{country.id})
                   #{category_join}
                   group by r.id,r.name,lon,lat,r.name,r.path,r.code,start_year,end_year
@@ -87,7 +87,7 @@ class GeoregionController < ApplicationController
                   END as url,
                   c.code, 'country' as type
                   from ((countries_projects as cp inner join projects_sites as ps on cp.project_id=ps.project_id and ps.site_id=#{@site.id}) inner join projects as p
-                  on cp.project_id=p.id and (p.end_date is null OR p.end_date > now() AND cp.country_id=#{country.id}) inner join countries as c on cp.country_id=c.id and c.id=#{country.id} )
+                  on cp.project_id=p.id and (cp.country_id=#{country.id}) inner join countries as c on cp.country_id=c.id and c.id=#{country.id} )
                   group by c.id,c.name,lon,lat,c.name,c.code,start_year,end_year"
       else
         @sql="select *
@@ -97,7 +97,7 @@ class GeoregionController < ApplicationController
           extract(year from end_date) as end_year
           from (countries_projects as cp
             inner join projects_sites as ps on cp.project_id=ps.project_id and site_id=#{@site.id})
-            inner join projects as p on ps.project_id=p.id and (p.end_date is null OR p.end_date > now())
+            inner join projects as p on ps.project_id=p.id
             #{category_join}
             inner join countries as c on cp.country_id=c.id and c.id=#{country.id}
           group by c.id,c.name,lon,lat,start_year,end_year) as subq"
@@ -141,7 +141,7 @@ class GeoregionController < ApplicationController
           END as url
           from (projects_regions as pr
             inner join projects_sites as ps on pr.project_id=ps.project_id and site_id=#{@site.id})
-            inner join projects as p on ps.project_id=p.id and (p.end_date is null OR p.end_date > now())
+            inner join projects as p on ps.project_id=p.id
             inner join regions as r on pr.region_id=r.id and r.id=#{@area.id} and r.level=#{@area.level}
             #{category_join}
           group by r.id,r.name,lon,lat) as subq"
@@ -156,7 +156,7 @@ class GeoregionController < ApplicationController
           r.code, 'region' as type
           from (projects_regions as pr
             inner join projects_sites as ps on pr.project_id=ps.project_id and site_id=#{@site.id})
-            inner join projects as p on ps.project_id=p.id and (p.end_date is null OR p.end_date > now())
+            inner join projects as p on ps.project_id=p.id
             inner join regions as r on pr.region_id=r.id and r.parent_region_id=#{@area.id} and r.level=#{@area.level+1}
             #{category_join}
           group by r.id,r.name,lon,lat) as subq"

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -143,7 +143,7 @@ class OrganizationsController < ApplicationController
                         r.code
                       FROM projects_regions AS pr
                       INNER JOIN projects_sites AS ps ON pr.project_id=ps.project_id AND ps.site_id=#{@site.id}
-                      INNER JOIN projects AS p ON pr.project_id=p.id AND (p.end_date is NULL OR p.end_date > now())
+                      INNER JOIN projects AS p ON pr.project_id=p.id
                       INNER JOIN regions AS r ON pr.region_id=r.id AND r.level=#{@site.levels_for_region.min} AND r.country_id=#{@filter_by_location.first}
                       #{category_join}
                       WHERE p.primary_organization_id = #{params[:id].sanitize_sql!.to_i}
@@ -158,7 +158,7 @@ class OrganizationsController < ApplicationController
                         '#{carry_on_url}' url,
                         c.code
                       FROM projects AS p
-                      INNER JOIN projects_sites AS ps ON ps.site_id=#{@site.id} and ps.project_id = p.id AND (p.end_date is NULL OR p.end_date > now())
+                      INNER JOIN projects_sites AS ps ON ps.site_id=#{@site.id} and ps.project_id = p.id
                       INNER JOIN donations on donations.project_id = p.id
                       INNER JOIN countries as c ON c.id = #{params[:location_id]}
                       INNER JOIN countries_projects as cp on cp.country_id = c.id AND cp.project_id = p.id
@@ -181,7 +181,7 @@ class OrganizationsController < ApplicationController
                          r.code
                   FROM projects_regions AS pr
                   INNER JOIN projects_sites AS ps ON pr.project_id=ps.project_id AND ps.site_id=#{@site.id}
-                  INNER JOIN projects AS p ON pr.project_id=p.id AND (p.end_date is NULL OR p.end_date > now())
+                  INNER JOIN projects AS p ON pr.project_id=p.id
                   INNER JOIN regions AS r ON pr.region_id=r.id AND r.level=#{@site.levels_for_region.min} AND r.country_id=#{@filter_by_location.shift} AND r.id IN (#{@filter_by_location.join(',')})
                   #{category_join}
                   WHERE p.primary_organization_id = #{params[:id].sanitize_sql!.to_i}

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -60,7 +60,7 @@ class SitesController < ApplicationController
                       iso2_code as code
                       from countries_projects as cp
                       inner join projects_sites as ps on cp.project_id=ps.project_id and site_id=#{@site.id}
-                      inner join projects as p on ps.project_id=p.id and (p.end_date is null OR p.end_date > now())
+                      inner join projects as p on ps.project_id=p.id
                       inner join countries as c on cp.country_id=c.id
                       group by c.id,c.name,lon,lat,iso2_code,start_year,end_year"
           end


### PR DESCRIPTION
When querying the database to generate map pin data, projects with an end_date in the past were being ignored.