### PR TITLE
speed up caching

### DIFF
--- a/app/jobs/cache_project.rb
+++ b/app/jobs/cache_project.rb
@@ -4,6 +4,5 @@ class CacheProject
   def self.perform( project_id )
     project = Project.find( project_id )
     project.set_cached_sites
-    project.update_data_denormalization
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -80,7 +80,6 @@ class Project < ActiveRecord::Base
   end)
 
   after_create :generate_intervention_id
-  after_save{ Resque.enqueue(CacheProject, self.id) }
   after_destroy{ Project.connection.execute("DELETE FROM data_denormalization WHERE project_id=#{self.id}") }
   before_validation :strip_urls
 
@@ -931,21 +930,22 @@ SQL
     generate_intervention_id if Project.where('intervention_id = ? AND id <> ?', intervention_id, id).count > 0
   end
 
-  def update_data_denormalization(opts = {levels: [1, 2, 3], force: false, sites: nil})
-    if !opts[:force] and self.cached_at.present? and Time.now - self.cached_at < 6.hours
+  def update_data_denormalization(opts = {levels: [1, 2, 3], force: false, sites: nil, sleep: 10})
+    # don't cache projects that have been recently cached
+    if !opts[:force] and self.cached_at.present? and Time.now - self.cached_at < 12.hours
       return
-    else
-      self.update_attribute(:cached_at, Time.now)
     end
 
-    while Time.now - self.updated_at < 10.seconds
-      sleep 10
-      self.reload
+    # don't cache projects that have been updated since the last time they were cached
+    if !opts[:force] and self.cached_at.present? and self.updated_at < self.cached_at
+      return
     end
+
+    sleep opts[:sleep] if opts[:sleep].is_a? Integer
 
     sites = opts[:sites]
-    sites ||= Site.where(global: true)
-    sites ||= Site.all
+    sites ||= Site.where(global: true).to_a
+    sites = Site.all if sites.length == 0
     site_ids = sites.collect { |s| s.id if s.respond_to? :id }
 
     connection = ActiveRecord::Base.connection
@@ -1051,9 +1051,12 @@ SQL
           ) AS subq;
         INSERT_NEW_ROW
       end  
-    end
 
-    self.update_attribute(:cached_at, Time.now)
+      # set cached_at only if called with default options
+      if opts[:levels] == [1,2,3] and opts[:force] == false and opts[:sites].nil?
+        self.update_attribute(:cached_at, Time.now)
+      end
+    end
   end
 
   ##############################

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1051,14 +1051,14 @@ SQL
           ) AS subq;
         INSERT_NEW_ROW
       end  
+    end
 
-      # set cached_at only if called with default options
-      if opts[:levels] == [1,2,3] and opts[:force] == false and opts[:sites].nil?
-        self.update_attribute(:cached_at, Time.now)
-      end
+    # set cached_at only if called with default options
+    if opts[:levels] == [1,2,3] and opts[:force] == false and opts[:sites].nil?
+      self.update_attribute(:cached_at, Time.now)
     end
   end
-
+  
   ##############################
   # PROJECT SYNCHRONIZATION
 

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -731,12 +731,9 @@ SQL
   end
 
   def set_cached_projects_by_level(level)
-    Project.where("updated_at > ?", Time.now - 24.hours).where("cached_at IS NULL OR cached_at < ?", Time.now - 24.hours).find_in_batches(batch_size: 100) do |batch|
-      batch.each do |project|
-        project.update_data_denormalization
-      end
+    Project.where("updated_at > ?", Time.now - 24.hours).where("cached_at IS NULL OR cached_at < ?", Time.now - 24.hours).find_each do |project|
+      project.update_data_denormalization
     end
-
   end
 
   def remove_cached_projects

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -733,56 +733,7 @@ SQL
   def set_cached_projects_by_level(level)
     Project.where("updated_at > ?", Time.now - 24.hours).where("cached_at IS NULL OR cached_at < ?", Time.now - 24.hours).find_in_batches(batch_size: 100) do |batch|
       batch.each do |project|
-        # Delete what we're about to insert
-        ActiveRecord::Base.connection.execute("DELETE FROM data_denormalization WHERE site_id = #{self.id} and project_id = #{project.id} and level = #{level} ")
-
-        sql="insert into data_denormalization(project_id,level,project_name,project_description,organization_id,organization_name,start_date,end_date,regions,regions_ids,countries,countries_ids,sectors,sector_ids,clusters,cluster_ids,donors_ids,activities,activities_ids,audiences,audiences_ids,diseases,diseases_ids,is_active,site_id,created_at)
-              select * from
-               (SELECT p.id as project_id, #{level} as level, p.name as project_name, p.description as project_description,
-               o.id as organization_id, o.name as organization_name,
-               p.start_date as start_date ,
-               p.end_date as end_date,
-               '|'||array_to_string(array_agg(distinct r.name),'|')||'|' as regions,
-               ('{'||array_to_string(array_agg(distinct r.id),',')||'}')::integer[] as regions_ids,
-               '|'||array_to_string(array_agg(distinct c.name),'|')||'|' as countries,
-               ('{'||array_to_string(array_agg(distinct c.id),',')||'}')::integer[] as countries_ids,
-               '|'||array_to_string(array_agg(distinct sec.name),'|')||'|' as sectors,
-               ('{'||array_to_string(array_agg(distinct sec.id),',')||'}')::integer[] as sector_ids,
-               '|'||array_to_string(array_agg(distinct clus.name),'|')||'|' as clusters,
-               ('{'||array_to_string(array_agg(distinct clus.id),',')||'}')::integer[] as cluster_ids,
-               ('{'||array_to_string(array_agg(distinct d.donor_id),',')||'}')::integer[] as donors_ids,
-               '|'||array_to_string(array_agg(distinct act.name),'|')||'|' as activities,
-               ('{'||array_to_string(array_agg(distinct act.id),',')||'}')::integer[] as activities_ids,
-               '|'||array_to_string(array_agg(distinct aud.name),'|')||'|' as audiences,
-               ('{'||array_to_string(array_agg(distinct aud.id),',')||'}')::integer[] as audiences_ids,
-               '|'||array_to_string(array_agg(distinct dis.name),'|')||'|' as diseases,
-               ('{'||array_to_string(array_agg(distinct dis.id),',')||'}')::integer[] as diseases_ids,
-         
-               CASE WHEN end_date is null OR p.end_date > now() THEN true ELSE false END AS is_active,
-               ps.site_id,p.created_at
-               FROM projects as p
-               INNER JOIN organizations as o ON p.primary_organization_id=o.id
-               INNER JOIN projects_sites as ps ON p.id=ps.project_id
-               LEFT JOIN projects_regions as pr ON pr.project_id=p.id
-               LEFT JOIN regions as r ON pr.region_id=r.id and r.level=#{level}
-               LEFT JOIN countries_projects as cp ON cp.project_id=p.id
-               LEFT JOIN countries as c ON c.id=cp.country_id OR c.id = r.country_id
-               LEFT JOIN clusters_projects as cpro ON cpro.project_id=p.id
-               LEFT JOIN clusters as clus ON clus.id=cpro.cluster_id
-               LEFT JOIN projects_sectors as psec ON psec.project_id=p.id
-               LEFT JOIN sectors as sec ON sec.id=psec.sector_id
-               LEFT JOIN donations as d ON d.project_id=ps.project_id
-               LEFT JOIN projects_activities as actpro ON actpro.project_id=p.id          
-               LEFT JOIN activities as act ON act.id=actpro.activity_id
-               LEFT JOIN projects_audiences as audpro ON audpro.project_id=p.id
-               LEFT JOIN audiences as aud ON aud.id=audpro.audience_id
-               LEFT JOIN diseases_projects as dispro on dispro.project_id=p.id
-               LEFT JOIN diseases as dis ON dis.id=dispro.disease_id
-                
-               where site_id=#{self.id} and p.id = #{project.id}
-               GROUP BY p.id,p.name,o.id,o.name,p.description,p.start_date,p.end_date,ps.site_id,p.created_at) as subq"
-        ActiveRecord::Base.connection.execute(sql)
-#        sleep 10 # To try and allow other things to get in there in between calls
+        project.update_data_denormalization
       end
     end
 


### PR DESCRIPTION
Try to make caching more efficient, primarily with two changes:

1.) Don't generate large arrays of Project objects when determining projects to cache.
2.) Don't select any geometry data into ActiveRecord objects when caching projects.