### PR TITLE
Hide some project fields

### DIFF
--- a/app/views/admin/projects/_form.html.erb
+++ b/app/views/admin/projects/_form.html.erb
@@ -674,18 +674,6 @@
     </span>
   </div>
 
-  <div id="idprefugee_camp" class="field">
-    <span class="chars">
-      <label>IDP/REFUGEE CAMP</label>
-      <% idprefugee_camp = f.object.idprefugee_camp || '' %>
-      <p id="chars_left_camp"><%= 150 - idprefugee_camp.length %> chars left</p>
-    </span>
-
-    <span class="textarea">
-      <%= f.text_area :idprefugee_camp, :onkeyup=>"limitChars('project_idprefugee_camp', 150, 'chars_left_camp')" %>
-    </span>
-  </div>
-
 <!-- ##################### CONTACT INFORMATION ##################### -->
 
   <h3 class="section museo_sans">CONTACT INFORMATION</h3>

--- a/app/views/admin/projects/_form.html.erb
+++ b/app/views/admin/projects/_form.html.erb
@@ -426,53 +426,6 @@
 <!-- ##################### CONTEXT ##################### -->
 
   <h3 class="section museo_sans">CONTEXT</h3>
-  <div id="clusters_content" class="field">
-    <label>CLUSTERS <span class="info">(Only valid for UN-coordinated emergencies.)</span>
-      <!-- FIELD DESCRIPTION -->
-      <div class="field_info">
-        <span class="info">i</span>
-        <div class="field_text">
-          <div class="top">
-            <a href="#close">x</a>
-          </div>
-          <div class="bottom">
-            <h3>Cluster</h3>
-            <span class="scroll">
-            <p>United Nations Cluster to which a project or donation is reported. Only applicable for certain emergencies.</p>
-            </span>
-          </div>
-        </div>
-      </div>
-      <!-- END FIELD DESCRIPTION -->
-
-
-    </label>
-
-      <ul class="clusters">
-        <% unless @project.clusters.empty? %>
-          <% @project.clusters.each do |cluster| %>
-          <li id="cluster_<%= cluster.id %>">
-            <p><%= cluster.name %></p><input id="<%= cluster.id %>" type="checkbox" name="project[cluster_ids][]" value="<%= cluster.id %>" checked="true"/><a href="#cluster_<%= cluster.id %>" class="remove_this close"></a>
-          </li>
-          <% end -%>
-        <% end -%>
-      </ul>
-    <div class="cluster_options">
-      <span class="combo_cluster_options">
-        <%= errors_for_span(@project, :clusters) %>
-        <p id="clusters_0">Select more clusters</p>
-        <div class="wrapper">
-          <ul class="options scroll_pane">
-          <% Cluster.get_select_values.collect do |cluster| %>
-            <li><a id="clusters_<%= cluster.id %>"><%= cluster.name %></a></li>
-          <% end %>
-            <li class="last"></li>
-          </ul>
-        </div>
-      </span>
-      <a id="add_cluster_bttn" class="add_cluster museo_sans shadow_green">add cluster</a>
-    </div>
-  </div>
   <div class="field">
     <label>SECTORS  <strong>*</strong></label>
 <!--     <span id="hidden" class="combo_large <%= 'error' if @project.errors[:sectors].present? %>">

--- a/app/views/admin/projects/_form.html.erb
+++ b/app/views/admin/projects/_form.html.erb
@@ -539,31 +539,6 @@
       <%= f.text_field :partner_organizations %>
     </span>
   </div> <!-- field -->
-  <div class="field">
-    <label>PRIME AWARDEE
-      <strong>&nbsp;</strong>
-      <!-- FIELD DESCRIPTION -->
-      <div class="field_info">
-        <span class="info">i</span>
-        <div class="field_text">
-          <div class="top">
-            <a href="#close">x</a>
-          </div>
-          <div class="bottom">
-            <h3>Prime Awardee</h3>
-            <span class="scroll">
-            <p>Name of the organization that received the funding directly from the donor.</p>
-            </span>
-          </div>
-        </div>
-      </div>
-      <!-- END FIELD DESCRIPTION -->
-
-    </label>
-    <span class="input_large">
-      <%= f.text_field :awardee_type %>
-    </span>
-  </div>
 
 <!-- ##################### PROJECT IMPACT ##################### -->
 

--- a/app/views/admin/projects/_form.html.erb
+++ b/app/views/admin/projects/_form.html.erb
@@ -61,12 +61,6 @@
       <%= f.text_field :organization_id %>
     </span>
   </div>
-  <div class="field">
-    <p class="title">TAGS <span class="info">Use comma (",") to separate project tags</span></p>
-    <span id="tags_combo" class="input_large">
-      <%= f.text_field :tags, :value => @project.tags.map{ |tag| tag.name }.join(', ') %>
-    </span>
-  </div>
 
 <!-- ##################### PROJECT DETAILS ##################### -->
 

--- a/app/views/admin/projects/_form.html.erb
+++ b/app/views/admin/projects/_form.html.erb
@@ -458,34 +458,6 @@
       <a class="add_sector museo_sans shadow_green">add sector</a>
     </div>
   </div>
-  <div id="cross_cutting" class="field">
-    <span class="chars">
-      <label>CROSS-CUTTING ISSUES
-        <strong>&nbsp;</strong>
-        <!-- FIELD DESCRIPTION -->
-        <div class="field_info">
-          <span class="info">i</span>
-          <div class="field_text">
-            <div class="top">
-              <a href="#close">x</a>
-            </div>
-            <div class="bottom">
-              <h3>Cross-cutting issues</h3>
-              <span class="scroll">
-              <p>Issues that cut across more than one sector, or that should not be managed as a sector, such as gender or the environment. Separate multiple entries with a comma.</p>
-              </span>
-            </div>
-          </div>
-        </div>
-        <!-- END FIELD DESCRIPTION -->
-      </label>
-      <% cross_cutting_issues = f.object.cross_cutting_issues || '' %>
-      <p id="chars_left_cross_cutting_issues"><%= 2000 - cross_cutting_issues.length %> chars left</p>
-    </span>
-    <span class="textarea">
-      <%= f.text_area :cross_cutting_issues, :onkeyup=>"limitChars('project_cross_cutting_issues', 2000, 'chars_left_cross_cutting_issues')" %>
-    </span>
-  </div>
 
 <!-- ##################### PROJECT MANAGEMENT ##################### -->
 

--- a/app/views/admin/sites/_form.html.erb
+++ b/app/views/admin/sites/_form.html.erb
@@ -114,15 +114,6 @@
         </span>
       </div>
     </li>
-    <li id="include_tags" class="<%= 'selected' if @site.project_context_tags? %>">
-      <a class="check">Include only matching some tags</a>
-      <div class="content">
-        <span class="tags_site">
-          <%= f.text_field :project_context_tags, {:id => 'pc_tags_section'} %>
-
-        </span>
-      </div>
-    </li>
   </ul>
   </div> <!-- field -->
   <h3 class="section museo_sans">CONTACT INFORMATION</h3>

--- a/app/views/admin/sites/_form.html.erb
+++ b/app/views/admin/sites/_form.html.erb
@@ -82,10 +82,6 @@
             <%= f.hidden_field :project_context_cluster_id  %>
             <div class="wrapper">
               <ul class="clusters_or_sectors scroll_pane">
-                <li class="section"><p>CLUSTERS</p></li>
-                <% Cluster.get_select_values.each do |cluster| %>
-                  <li><a class="cluster_value" id="cluster_<%= cluster.id %>"><%= truncate(cluster.name, :length => 30)  %></a></li>
-                <%end -%>
                 <%= f.hidden_field :project_context_sector_id  %>
                 <li class="section"><p>SECTORS</p></li>
                 <% Sector.get_select_values.each do |sector| %>

--- a/app/views/admin/sites/_form_customization.html.erb
+++ b/app/views/admin/sites/_form_customization.html.erb
@@ -133,7 +133,7 @@
   <div class="common">
     <h3>NAMING</h3>
     <div class="field">
-      <%= f.label :word_for_clusters, "Word for clusters / sectors" %>
+      <%= f.label :word_for_clusters, "Word for sectors" %>
       <%= f.text_field :word_for_clusters, :class=>"short" %>
     </div>
     <div class="field">

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -211,13 +211,6 @@
               <%end%>
               </section>
 
-              <section>
-              <%unless @project.cross_cutting_issues.blank? %>
-                <h2 class="<%= (@project.activities.blank? && @project.additional_information.blank?)? 'first':''%>">Cross-cutting issues</h2>
-                <p> <%= raw(@project.cross_cutting_issues) %> </p>
-              <%end%>
-            </section>
-
             <section>
               <%if @locations.present? && @locations.to_a.join.present? %>
                 <h2 class="<%= (@project.activities.blank? && @project.additional_information.blank? && @project.cross_cutting_issues.blank?)? 'first':''%>">

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -84,13 +84,6 @@
           </div>
         <% end %>
 
-        <% if @project.awardee_type.present? %>
-          <div class="mod-info">
-            <h3>Prime Awardee</h3>
-            <p><%= @project.awardee_type %></p>
-          </div>
-        <% end %>
-
         <% if @project.implementing_organization? %>
           <div class="mod-info">
             <h3>International Partners</h3>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -26,17 +26,6 @@
           </div>
 
           <% if @navigate_by_cluster %>
-            <div class="block cluster">
-              <h3><%= @site.word_for_clusters %></h3>
-              <select name="clusters_ids[]" multiple placeholder="All clusters">
-                <% @clusters.each do |cluster| %>
-                  <option value="<%= cluster.id %>"><%= cluster.title %></option>
-                <% end %>
-                <% @filtered_clusters.each do |region| %>
-                  <option selected value="<%= region.id %>"><%= region.title %></option>
-                <% end %>
-              </select>
-            </div>
           <% else %>
             <div class="block sectors">
               <h3><%= @site.word_for_clusters %></h3>

--- a/app/views/templates/index.html.erb
+++ b/app/views/templates/index.html.erb
@@ -46,8 +46,6 @@
 
       <%# render 'partials/aside/donors' %>
 
-      <%# render 'partials/aside/prime_awardee' %>
-
       <%# render 'partials/aside/local_partners' %>
 
       <%# render 'partials/aside/people_reached' %>


### PR DESCRIPTION
Removes exposure of tags, clusters, cross-cutting issues, prime awardee, and IDP/refugee camp fields throughout the interface.

Probably best to leave this stuff in the backend for now; these things are kind of baked into the project on several levels and deleting them outright might inadvertently break something -- this is especially true of clusters.